### PR TITLE
Fixed typographical error, changed Carribean to Caribbean in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ The following is a list of all of the challenges used for the 2013 CTF along wit
     <td>Plot Lines</td>
     <td>300</td>
     <td><a href="https://github.com/mitre-cyber-academy/2013-networking-300">2013-networking-300</a></td>
-    <td>While Captain Jack Sparrow is off galavanting about with his jar of dirt, there is still treasure to be discovered in the Carribean. See if you can figure out the riddles to find the greatest treasure of them all, and remember: X marks the spot.</td>
+    <td>While Captain Jack Sparrow is off galavanting about with his jar of dirt, there is still treasure to be discovered in the Caribbean. See if you can figure out the riddles to find the greatest treasure of them all, and remember: X marks the spot.</td>
   </tr>
 
   <tr>


### PR DESCRIPTION
mitre-cyber-academy, I've corrected a typographical error in the documentation of the [2013-ctf-game](https://github.com/mitre-cyber-academy/2013-ctf-game) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
